### PR TITLE
Fix ElasticSearch variables to have common configuration names for #2022

### DIFF
--- a/src/main/java/com/epam/reportportal/config/rabbit/BackgroundProcessingConfiguration.java
+++ b/src/main/java/com/epam/reportportal/config/rabbit/BackgroundProcessingConfiguration.java
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Configuration;
  * @author <a href="mailto:maksim_antonov@epam.com">Maksim Antonov</a>
  */
 @Configuration
-@ConditionalOnProperty(prefix = "rp.elasticsearch", name = "host")
+@ConditionalOnProperty(prefix = "rp.es", name = "host")
 public class BackgroundProcessingConfiguration {
 
   public static final String LOG_MESSAGE_SAVING_QUEUE_NAME = "log_message_saving";

--- a/src/main/java/com/epam/reportportal/elastic/SimpleElasticSearchClient.java
+++ b/src/main/java/com/epam/reportportal/elastic/SimpleElasticSearchClient.java
@@ -25,7 +25,7 @@ import org.springframework.web.client.RestTemplate;
  */
 @Primary
 @Service
-@ConditionalOnProperty(prefix = "rp.elasticsearch", name = "host")
+@ConditionalOnProperty(prefix = "rp.es", name = "host")
 public class SimpleElasticSearchClient implements ElasticSearchClient {
 
   protected final Logger LOGGER = LoggerFactory.getLogger(SimpleElasticSearchClient.class);
@@ -33,9 +33,9 @@ public class SimpleElasticSearchClient implements ElasticSearchClient {
   private final String host;
   private final RestTemplate restTemplate;
 
-  public SimpleElasticSearchClient(@Value("${rp.elasticsearch.host}") String host,
-      @Value("${rp.elasticsearch.username:}") String username,
-      @Value("${rp.elasticsearch.password:}") String password) {
+  public SimpleElasticSearchClient(@Value("${rp.es.host}") String host,
+      @Value("${rp.es.username:}") String username,
+      @Value("${rp.es.password:}") String password) {
     restTemplate = new RestTemplate();
 
     if (!username.isEmpty() && !password.isEmpty()) {

--- a/src/main/java/com/epam/reportportal/jobs/processing/SaveLogMessageJob.java
+++ b/src/main/java/com/epam/reportportal/jobs/processing/SaveLogMessageJob.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
  * @author <a href="mailto:maksim_antonov@epam.com">Maksim Antonov</a>
  */
 @Service
-@ConditionalOnProperty(prefix = "rp.elasticsearch", name = "host")
+@ConditionalOnProperty(prefix = "rp.es", name = "host")
 public class SaveLogMessageJob {
 
   public static final String LOG_MESSAGE_SAVING_QUEUE_NAME = "log_message_saving";

--- a/src/main/java/com/epam/reportportal/log/LogProcessing.java
+++ b/src/main/java/com/epam/reportportal/log/LogProcessing.java
@@ -15,7 +15,7 @@ import org.springframework.util.CollectionUtils;
  * @author <a href="mailto:maksim_antonov@epam.com">Maksim Antonov</a>
  */
 @Component
-@ConditionalOnProperty(prefix = "rp.elasticsearch", name = "host")
+@ConditionalOnProperty(prefix = "rp.es", name = "host")
 public class LogProcessing extends BatchProcessing<LogMessage> {
 
   private final ElasticSearchClient elasticSearchClient;


### PR DESCRIPTION
This PR was made according https://github.com/reportportal/reportportal/issues/2022

The mess of ES hosts in the docker-compose file leads to confusion. Currently, each service has its own syntax from ES property. 

I changed names to have common format