### PR TITLE
Feature/epmrpp 98957 add reusable Java workflow with authorization and Jobs service for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,44 +1,15 @@
-name: Release
+name: Release Workflow
 
 on:
-  push:
-    branches:
-      - master
-    paths-ignore:
-      - '.github/**'
-      - README.md
-      - gradle.properties
-
-env:
-  GH_USER_NAME: github.actor
-  REPOSITORY_URL: 'https://maven.pkg.github.com/'
+  release:
+    types: [published]
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+  publish-artifacts:
+    uses: reportportal/.github/.github/workflows/java-build-release.yaml@feature/EPMRPP-98957
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'adopt'
-          java-version: '21'
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      - name: Setup git credentials
-        uses: oleksiyrudenko/gha-git-credentials@v2
-        with:
-          name: 'reportportal.io'
-          email: 'support@reportportal.io'
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Release with Gradle
-        id: release
-        run: |
-          ./gradlew release -PreleaseMode \
-          -PgithubUserName=${{env.GH_USER_NAME}} -PgithubToken=${{secrets.GITHUB_TOKEN}} \
-          -PgpgPassphrase=${{secrets.GPG_PASSPHRASE}} -PgpgPrivateKey="${{secrets.GPG_PRIVATE_KEY}}"
+    with:
+      release_version: ${{ github.event.release.tag_name }}
+      repository_url: 'https://maven.pkg.github.com/'
+      gradle_command: ./gradlew build
+      branch: feature/EPMRPP-98957

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,4 @@ jobs:
 
     with:
       release_version: ${{ github.event.release.tag_name }}
-      artifact_upload_url: 'https://maven.pkg.github.com/'
       java_version: "21"
-      branch: master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   publish-artifacts:
-    uses: reportportal/.github/.github/workflows/java-build-release.yaml@feature/EPMRPP-98957
+    uses: reportportal/.github/.github/workflows/java-build-release.yaml@main
 
     with:
       release_version: ${{ github.event.release.tag_name }}
       repository_url: 'https://maven.pkg.github.com/'
       gradle_command: ./gradlew build
-      branch: feature/EPMRPP-98957
+      branch: master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,6 @@ jobs:
 
     with:
       release_version: ${{ github.event.release.tag_name }}
-      repository_url: 'https://maven.pkg.github.com/'
-      gradle_command: ./gradlew build
+      artifact_upload_url: 'https://maven.pkg.github.com/'
+      java_version: "21"
       branch: master

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=v5.test.release
+version=5.13.0
 description=EPAM Report portal. Service jobs
 dockerServerUrl=unix:///var/run/docker.sock
 dockerPrepareEnvironment=

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=5.13.0
+version=v5.test.release
 description=EPAM Report portal. Service jobs
 dockerServerUrl=unix:///var/run/docker.sock
 dockerPrepareEnvironment=


### PR DESCRIPTION
**Java Build and Release Automation:**

The workflow handles Java project builds, ensuring that the service artifacts are consistently compiled and published.
Integrated with Gradle to execute the defined build command (./gradlew build).

**Master Branch Enforcement:**

The branch input is now explicitly set to master, ensuring that the workflow is always executed on the correct branch.
Removed redundant branch validation since the checkout step enforces this behavior.

**Improved Release Management:**

Ensures that artifacts are built and uploaded according to the release version.
Prevents issues where outdated or mismatched builds could be published.