### PR TITLE
Remove explicit volume for /tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,5 @@ ENV APP_DIR=/usr/app
 ENV JAVA_OPTS="-Xmx1g -XX:+UseG1GC -XX:InitiatingHeapOccupancyPercent=70 -Djava.security.egd=file:/dev/./urandom"
 WORKDIR $APP_DIR
 COPY --from=build $APP_DIR/build/libs/service-jobs-*exec.jar .
-VOLUME ["/tmp"]
 EXPOSE 8686
 ENTRYPOINT exec java ${JAVA_OPTS} -jar ${APP_DIR}/service-jobs-*exec.jar


### PR DESCRIPTION
If not mounted explicitly, it creates an anonymous volume which is not deleted automatically when the container is deleted.