### PR TITLE
EPMRPP-107138 || Update expired user job to delete users and their personal orgs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,9 +104,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.mockito:mockito-core:5.7.0'
-    testImplementation 'net.bytebuddy:byte-buddy:1.14.5'
-    testImplementation 'net.bytebuddy:byte-buddy-agent:1.14.5'
-
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.7.0'
 }
 
 test {

--- a/src/main/java/com/epam/reportportal/jobs/clean/DeleteExpiredUsersJob.java
+++ b/src/main/java/com/epam/reportportal/jobs/clean/DeleteExpiredUsersJob.java
@@ -282,7 +282,7 @@ public class DeleteExpiredUsersJob extends BaseJob {
   }
 
 
-  private static class User {
+  static class User {
 
     private long userId;
     private String email;
@@ -304,7 +304,7 @@ public class DeleteExpiredUsersJob extends BaseJob {
     }
   }
 
-  private static class ProjectOrganization {
+  static class ProjectOrganization {
 
     private Long projectId;
     private Long organizationId;

--- a/src/main/java/com/epam/reportportal/jobs/clean/DeleteExpiredUsersJob.java
+++ b/src/main/java/com/epam/reportportal/jobs/clean/DeleteExpiredUsersJob.java
@@ -67,16 +67,16 @@ public class DeleteExpiredUsersJob extends BaseJob {
 
   private static final String SELECT_EXPIRED_USERS = """
       SELECT
-      	u.id AS user_id,
-      	u.email AS user_email
+          u.id AS user_id,
+          u.email AS user_email
       FROM users u
       LEFT JOIN api_keys ak ON u.id = ak.user_id
       WHERE
-      	(u.metadata->'metadata'->>'last_login')::BIGINT <= :retentionPeriod
-      	AND (ak.user_id IS NULL
-      		OR (EXTRACT(EPOCH FROM ak.last_used_at) * 1000)::BIGINT <= :retentionPeriod
-      		OR NOT EXISTS (SELECT 1 FROM api_keys WHERE user_id = u.id AND last_used_at IS NOT NULL))
-      	AND u.role != 'ADMINISTRATOR'
+          (u.metadata->'metadata'->>'last_login')::BIGINT <= :retentionPeriod
+          AND (ak.user_id IS NULL
+              OR (EXTRACT(EPOCH FROM ak.last_used_at) * 1000)::BIGINT <= :retentionPeriod
+              OR NOT EXISTS (SELECT 1 FROM api_keys WHERE user_id = u.id AND last_used_at IS NOT NULL))
+          AND u.role != 'ADMINISTRATOR'
       GROUP BY u.id
       """;
 
@@ -187,7 +187,7 @@ public class DeleteExpiredUsersJob extends BaseJob {
   private void publishEmailNotificationEvents(List<String> userEmails) {
     List<EmailNotificationRequest> notifications = userEmails.stream()
         .map(recipient -> new EmailNotificationRequest(recipient, USER_DELETION_TEMPLATE))
-        .collect(Collectors.toList());
+        .toList();
     messageBus.publishEmailNotificationEvents(notifications);
   }
 

--- a/src/main/java/com/epam/reportportal/model/activity/Activity.java
+++ b/src/main/java/com/epam/reportportal/model/activity/Activity.java
@@ -20,7 +20,7 @@ import com.epam.reportportal.model.activity.enums.EventAction;
 import com.epam.reportportal.model.activity.enums.EventObject;
 import com.epam.reportportal.model.activity.enums.EventPriority;
 import com.epam.reportportal.model.activity.enums.EventSubject;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 /**
  * A model that represents the state of the Activity.
@@ -29,7 +29,7 @@ import java.time.LocalDateTime;
  */
 public class Activity {
 
-  private LocalDateTime createdAt;
+  private Instant createdAt;
   private EventAction action;
   private String eventName;
   private EventPriority priority;
@@ -38,6 +38,7 @@ public class Activity {
   private EventObject objectType;
   private Long projectId;
   private String projectName;
+  private Long organizationId;
   private Long subjectId;
   private String subjectName;
   private EventSubject subjectType;
@@ -47,11 +48,11 @@ public class Activity {
     this.isSavedEvent = true;
   }
 
-  public LocalDateTime getCreatedAt() {
+  public Instant getCreatedAt() {
     return createdAt;
   }
 
-  public void setCreatedAt(LocalDateTime createdAt) {
+  public void setCreatedAt(Instant createdAt) {
     this.createdAt = createdAt;
   }
 
@@ -119,6 +120,14 @@ public class Activity {
     this.projectName = projectName;
   }
 
+  public Long getOrganizationId() {
+    return organizationId;
+  }
+
+  public void setOrganizationId(Long organizationId) {
+    this.organizationId = organizationId;
+  }
+
   public Long getSubjectId() {
     return subjectId;
   }
@@ -170,7 +179,7 @@ public class Activity {
     }
 
     public ActivityBuilder addCreatedNow() {
-      activity.setCreatedAt(LocalDateTime.now());
+      activity.setCreatedAt(Instant.now());
       return this;
     }
 
@@ -211,6 +220,11 @@ public class Activity {
 
     public ActivityBuilder addProjectName(String projectName) {
       activity.setProjectName(projectName);
+      return this;
+    }
+
+    public ActivityBuilder addOrganizationId(Long organizationId) {
+      activity.setOrganizationId(organizationId);
       return this;
     }
 

--- a/src/main/java/com/epam/reportportal/model/activity/event/UnassignUserEvent.java
+++ b/src/main/java/com/epam/reportportal/model/activity/event/UnassignUserEvent.java
@@ -32,9 +32,11 @@ import com.epam.reportportal.model.activity.enums.EventSubject;
 public class UnassignUserEvent implements ActivityEvent {
 
   private final Long projectId;
+  private final Long organizationId;
 
-  public UnassignUserEvent(Long projectId) {
+  public UnassignUserEvent(Long projectId, Long organizationId) {
     this.projectId = projectId;
+    this.organizationId = organizationId;
   }
 
   @Override
@@ -46,6 +48,7 @@ public class UnassignUserEvent implements ActivityEvent {
         .addObjectType(EventObject.USER)
         .addObjectName("deleted_user")
         .addProjectId(projectId)
+        .addOrganizationId(organizationId)
         .addSubjectName(EventSubject.APPLICATION.getApplicationName())
         .addSubjectType(EventSubject.APPLICATION)
         .addPriority(EventPriority.MEDIUM)

--- a/src/test/java/com/epam/reportportal/jobs/clean/DeleteExpiredUsersJobTest.java
+++ b/src/test/java/com/epam/reportportal/jobs/clean/DeleteExpiredUsersJobTest.java
@@ -1,0 +1,357 @@
+package com.epam.reportportal.jobs.clean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.epam.reportportal.analyzer.index.IndexerServiceClient;
+import com.epam.reportportal.model.EmailNotificationRequest;
+import com.epam.reportportal.model.activity.ActivityEvent;
+import com.epam.reportportal.service.MessageBus;
+import com.epam.reportportal.storage.DataStorageService;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteExpiredUsersJobTest {
+
+  @Mock
+  private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+  @Mock
+  private DataStorageService dataStorageService;
+
+  @Mock
+  private IndexerServiceClient indexerServiceClient;
+
+  @Mock
+  private MessageBus messageBus;
+
+  @InjectMocks
+  private DeleteExpiredUsersJob deleteExpiredUsersJob;
+
+  @Captor
+  private ArgumentCaptor<ActivityEvent> activityCaptor;
+
+  @Captor
+  private ArgumentCaptor<List<EmailNotificationRequest>> emailCaptor;
+
+  @BeforeEach
+  void setUp() {
+    setRetentionPeriod(30L);
+  }
+
+  @Test
+  void execute_WhenExpiredUsersFound_ShouldDeleteUsersAndPublishEvents() throws Exception {
+    // Given
+    DeleteExpiredUsersJob.User user1 = createUser(1L, "user1@test.com");
+    DeleteExpiredUsersJob.User user2 = createUser(2L, "user2@test.com");
+    List<DeleteExpiredUsersJob.User> expiredUsers = List.of(user1, user2);
+    List<Long> personalProjectIds = List.of(10L, 20L);
+    List<DeleteExpiredUsersJob.ProjectOrganization> nonPersonalProjects = List.of(
+        createProjectOrganization(100L, 1L),
+        createProjectOrganization(200L, 2L)
+    );
+    List<String> userAttachments = List.of("attachment1", "attachment2");
+
+    when(namedParameterJdbcTemplate.query(anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(expiredUsers);
+    when(namedParameterJdbcTemplate.queryForList(anyString(), any(MapSqlParameterSource.class), eq(Long.class)))
+        .thenReturn(personalProjectIds);
+    when(namedParameterJdbcTemplate.query(anyString(), any(Map.class), any(RowMapper.class)))
+        .thenReturn(nonPersonalProjects);
+    when(namedParameterJdbcTemplate.queryForList(anyString(), any(MapSqlParameterSource.class), eq(String.class)))
+        .thenReturn(userAttachments);
+
+    // When
+    deleteExpiredUsersJob.execute();
+
+    // Then
+    assertNotNull(deleteExpiredUsersJob);
+
+    verify(namedParameterJdbcTemplate, times(1))
+        .query(anyString(), any(MapSqlParameterSource.class), any(RowMapper.class));
+    verify(namedParameterJdbcTemplate, times(1))
+        .queryForList(anyString(), any(MapSqlParameterSource.class), eq(Long.class));
+    verify(namedParameterJdbcTemplate, times(1))
+        .query(anyString(), any(Map.class), any(RowMapper.class));
+    verify(namedParameterJdbcTemplate, times(1))
+        .queryForList(anyString(), any(MapSqlParameterSource.class), eq(String.class));
+
+    verify(dataStorageService, times(1)).deleteAll(anyList());
+    verify(indexerServiceClient, times(2)).removeSuggest(anyLong());
+    verify(indexerServiceClient, times(2)).deleteIndex(anyLong());
+    verify(messageBus, times(4)).publishActivity(activityCaptor.capture());
+
+    List<ActivityEvent> publishedActivities = activityCaptor.getAllValues();
+
+    long projectDeletedEvents = publishedActivities.stream()
+        .filter(activity -> activity.getClass().getSimpleName().equals("ProjectDeletedEvent"))
+        .count();
+    assertEquals(1, projectDeletedEvents);
+
+    long userDeletedEvents = publishedActivities.stream()
+        .filter(activity -> activity.getClass().getSimpleName().equals("UserDeletedEvent"))
+        .count();
+    assertEquals(1, userDeletedEvents);
+
+    long unassignUserEvents = publishedActivities.stream()
+        .filter(activity -> activity.getClass().getSimpleName().equals("UnassignUserEvent"))
+        .count();
+    assertEquals(2, unassignUserEvents);
+
+    verify(messageBus, times(1)).publishEmailNotificationEvents(emailCaptor.capture());
+    List<List<EmailNotificationRequest>> emailNotifications = emailCaptor.getAllValues();
+    assertEquals(1, emailNotifications.size());
+    assertEquals(2, emailNotifications.getFirst().size());
+  }
+
+  @Test
+  void execute_WhenNoExpiredUsersFound_ShouldNotDeleteAnything() throws Exception {
+    // Given
+    List<DeleteExpiredUsersJob.User> emptyUsers = Collections.emptyList();
+    when(namedParameterJdbcTemplate.query(anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(emptyUsers);
+
+    // When
+    deleteExpiredUsersJob.execute();
+
+    // Then
+    assertNotNull(deleteExpiredUsersJob);
+    assertTrue(emptyUsers.isEmpty());
+
+    verify(namedParameterJdbcTemplate, times(1))
+        .query(anyString(), any(MapSqlParameterSource.class), any(RowMapper.class));
+
+    verify(dataStorageService, never()).deleteAll(anyList());
+    verify(indexerServiceClient, never()).removeSuggest(anyLong());
+    verify(indexerServiceClient, never()).deleteIndex(anyLong());
+    verify(namedParameterJdbcTemplate, never()).update(anyString(), any(MapSqlParameterSource.class));
+    verify(messageBus, times(1)).publishActivity(any());
+    verify(messageBus, times(1)).publishEmailNotificationEvents(anyList());
+  }
+
+  @Test
+  void execute_WhenInvalidRetentionPeriod_ShouldNotDeleteUsers() throws Exception {
+    // Given
+    setRetentionPeriod(-1L);
+
+    // When
+    deleteExpiredUsersJob.execute();
+
+    // Then
+    assertNotNull(deleteExpiredUsersJob);
+    verify(namedParameterJdbcTemplate, never())
+        .query(anyString(), any(MapSqlParameterSource.class), any(RowMapper.class));
+    verify(dataStorageService, never()).deleteAll(anyList());
+    verify(indexerServiceClient, never()).removeSuggest(anyLong());
+    verify(indexerServiceClient, never()).deleteIndex(anyLong());
+    verify(namedParameterJdbcTemplate, never()).update(anyString(), any(MapSqlParameterSource.class));
+
+    verify(messageBus, never()).publishActivity(any());
+    verify(messageBus, never()).publishEmailNotificationEvents(anyList());
+  }
+
+  @Test
+  void execute_WhenDataStorageServiceThrowsException_ShouldContinueExecution() throws Exception {
+    // Given
+    DeleteExpiredUsersJob.User user = createUser(1L, "user@test.com");
+    List<DeleteExpiredUsersJob.User> expiredUsers = List.of(user);
+    List<Long> personalProjectIds = List.of(10L);
+    List<DeleteExpiredUsersJob.ProjectOrganization> nonPersonalProjects = Collections.emptyList();
+    List<String> userAttachments = List.of("attachment1");
+
+    when(namedParameterJdbcTemplate.query(anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(expiredUsers);
+    when(namedParameterJdbcTemplate.queryForList(anyString(), any(MapSqlParameterSource.class), eq(Long.class)))
+        .thenReturn(personalProjectIds);
+    when(namedParameterJdbcTemplate.query(anyString(), any(Map.class), any(RowMapper.class)))
+        .thenReturn(nonPersonalProjects);
+    when(namedParameterJdbcTemplate.queryForList(anyString(), any(MapSqlParameterSource.class), eq(String.class)))
+        .thenReturn(userAttachments);
+    doThrow(new RuntimeException("Storage error")).when(dataStorageService).deleteAll(anyList());
+
+    // When
+    deleteExpiredUsersJob.execute();
+
+    // Then
+    assertNotNull(deleteExpiredUsersJob);
+    assertEquals(1, expiredUsers.size());
+    assertEquals(1, personalProjectIds.size());
+
+    verify(dataStorageService, times(1)).deleteAll(anyList());
+    verify(indexerServiceClient, times(1)).removeSuggest(anyLong());
+    verify(indexerServiceClient, times(1)).deleteIndex(anyLong());
+    verify(messageBus, times(2)).publishActivity(any());
+    verify(messageBus, times(1)).publishEmailNotificationEvents(anyList());
+  }
+
+  @Test
+  void execute_WhenUsersHaveNoPersonalProjects_ShouldOnlyDeleteUsers() throws Exception {
+    // Given
+    DeleteExpiredUsersJob.User user = createUser(1L, "user@test.com");
+    List<DeleteExpiredUsersJob.User> expiredUsers = List.of(user);
+    List<Long> personalProjectIds = Collections.emptyList();
+    List<DeleteExpiredUsersJob.ProjectOrganization> nonPersonalProjects = List.of(
+        createProjectOrganization(100L, 1L)
+    );
+    List<String> userAttachments = List.of("attachment1");
+
+    when(namedParameterJdbcTemplate.query(anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(expiredUsers);
+    when(namedParameterJdbcTemplate.queryForList(anyString(), any(MapSqlParameterSource.class), eq(Long.class)))
+        .thenReturn(personalProjectIds);
+    when(namedParameterJdbcTemplate.query(anyString(), any(Map.class), any(RowMapper.class)))
+        .thenReturn(nonPersonalProjects);
+    when(namedParameterJdbcTemplate.queryForList(anyString(), any(MapSqlParameterSource.class), eq(String.class)))
+        .thenReturn(userAttachments);
+
+    // When
+    deleteExpiredUsersJob.execute();
+
+    // Then
+    assertNotNull(deleteExpiredUsersJob);
+    assertEquals(1, expiredUsers.size());
+    assertTrue(personalProjectIds.isEmpty());
+    assertEquals(1, nonPersonalProjects.size());
+
+    verify(dataStorageService, times(1)).deleteAll(anyList());
+    verify(indexerServiceClient, never()).removeSuggest(anyLong());
+    verify(indexerServiceClient, never()).deleteIndex(anyLong());
+    verify(messageBus, times(3)).publishActivity(activityCaptor.capture());
+
+    List<ActivityEvent> publishedActivities = activityCaptor.getAllValues();
+
+    long projectDeletedEvents = publishedActivities.stream()
+        .filter(activity -> activity.getClass().getSimpleName().equals("ProjectDeletedEvent"))
+        .count();
+    assertEquals(1, projectDeletedEvents, "Should have 1 ProjectDeletedEvent (even with 0 projects)");
+
+    long userDeletedEvents = publishedActivities.stream()
+        .filter(activity -> activity.getClass().getSimpleName().equals("UserDeletedEvent"))
+        .count();
+    assertEquals(1, userDeletedEvents, "Should have 1 UserDeletedEvent");
+
+    long unassignUserEvents = publishedActivities.stream()
+        .filter(activity -> activity.getClass().getSimpleName().equals("UnassignUserEvent"))
+        .count();
+    assertEquals(1, unassignUserEvents);
+
+    verify(messageBus, times(1)).publishEmailNotificationEvents(emailCaptor.capture());
+    List<List<EmailNotificationRequest>> emailNotifications = emailCaptor.getAllValues();
+    assertEquals(1, emailNotifications.size());
+    assertEquals(1, emailNotifications.getFirst().size());
+  }
+
+  @Test
+  void execute_ShouldPublishCorrectDeletionCounts() {
+    // Given
+    DeleteExpiredUsersJob.User user1 = createUser(1L, "user1@test.com");
+    DeleteExpiredUsersJob.User user2 = createUser(2L, "user2@test.com");
+    DeleteExpiredUsersJob.User user3 = createUser(3L, "user3@test.com");
+    List<DeleteExpiredUsersJob.User> expiredUsers = List.of(user1, user2, user3);
+    List<Long> personalProjectIds = List.of(10L, 20L, 30L, 40L); // 4 personal projects
+    List<DeleteExpiredUsersJob.ProjectOrganization> nonPersonalProjects = List.of(
+        createProjectOrganization(100L, 1L),
+        createProjectOrganization(200L, 2L)
+    );
+    List<String> userAttachments = List.of("attachment1", "attachment2", "attachment3");
+
+    when(namedParameterJdbcTemplate.query(anyString(), any(MapSqlParameterSource.class), any(RowMapper.class)))
+        .thenReturn(expiredUsers);
+    when(namedParameterJdbcTemplate.queryForList(anyString(), any(MapSqlParameterSource.class), eq(Long.class)))
+        .thenReturn(personalProjectIds);
+    when(namedParameterJdbcTemplate.query(anyString(), any(Map.class), any(RowMapper.class)))
+        .thenReturn(nonPersonalProjects);
+    when(namedParameterJdbcTemplate.queryForList(anyString(), any(MapSqlParameterSource.class), eq(String.class)))
+        .thenReturn(userAttachments);
+
+    // When
+    deleteExpiredUsersJob.execute();
+
+    // Then
+    verify(messageBus, times(4)).publishActivity(activityCaptor.capture());
+
+    List<ActivityEvent> publishedActivities = activityCaptor.getAllValues();
+
+    long projectDeletedEvents = publishedActivities.stream()
+        .filter(activity -> activity.getClass().getSimpleName().equals("ProjectDeletedEvent"))
+        .count();
+    assertEquals(1, projectDeletedEvents, "Should have 1 ProjectDeletedEvent");
+
+    long userDeletedEvents = publishedActivities.stream()
+        .filter(activity -> activity.getClass().getSimpleName().equals("UserDeletedEvent"))
+        .count();
+    assertEquals(1, userDeletedEvents, "Should have 1 UserDeletedEvent");
+
+    long unassignUserEvents = publishedActivities.stream()
+        .filter(activity -> activity.getClass().getSimpleName().equals("UnassignUserEvent"))
+        .count();
+    assertEquals(2, unassignUserEvents, "Should have 2 UnassignUserEvents");
+
+    verify(messageBus, times(1)).publishEmailNotificationEvents(emailCaptor.capture());
+    List<List<EmailNotificationRequest>> emailNotifications = emailCaptor.getAllValues();
+    assertEquals(1, emailNotifications.size());
+    assertEquals(3, emailNotifications.getFirst().size());
+
+    verify(indexerServiceClient, times(4)).removeSuggest(anyLong());
+    verify(indexerServiceClient, times(4)).deleteIndex(anyLong());
+  }
+
+  private DeleteExpiredUsersJob.User createUser(Long userId, String email) {
+    DeleteExpiredUsersJob.User user = new DeleteExpiredUsersJob.User();
+    user.setUserId(userId);
+    user.setEmail(email);
+    return user;
+  }
+
+  private DeleteExpiredUsersJob.ProjectOrganization createProjectOrganization(Long projectId, Long organizationId) {
+    DeleteExpiredUsersJob.ProjectOrganization projectOrg = new DeleteExpiredUsersJob.ProjectOrganization();
+    projectOrg.setProjectId(projectId);
+    projectOrg.setOrganizationId(organizationId);
+    return projectOrg;
+  }
+
+  private void setRetentionPeriod(Long retentionPeriod) {
+    try {
+      var field = DeleteExpiredUsersJob.class.getDeclaredField("retentionPeriod");
+      field.setAccessible(true);
+      field.set(deleteExpiredUsersJob, retentionPeriod);
+      assertEquals(retentionPeriod, getRetentionPeriod());
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to set retention period", e);
+    }
+  }
+
+  private Long getRetentionPeriod() {
+    try {
+      var field = DeleteExpiredUsersJob.class.getDeclaredField("retentionPeriod");
+      field.setAccessible(true);
+      return (Long) field.get(deleteExpiredUsersJob);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to get retention period", e);
+    }
+  }
+}

--- a/src/test/java/com/epam/reportportal/jobs/clean/DeleteExpiredUsersJobTest.java
+++ b/src/test/java/com/epam/reportportal/jobs/clean/DeleteExpiredUsersJobTest.java
@@ -17,6 +17,9 @@ import static org.mockito.Mockito.when;
 import com.epam.reportportal.analyzer.index.IndexerServiceClient;
 import com.epam.reportportal.model.EmailNotificationRequest;
 import com.epam.reportportal.model.activity.ActivityEvent;
+import com.epam.reportportal.model.activity.event.ProjectDeletedEvent;
+import com.epam.reportportal.model.activity.event.UnassignUserEvent;
+import com.epam.reportportal.model.activity.event.UserDeletedEvent;
 import com.epam.reportportal.service.MessageBus;
 import com.epam.reportportal.storage.DataStorageService;
 import java.util.Collections;
@@ -108,17 +111,17 @@ class DeleteExpiredUsersJobTest {
     List<ActivityEvent> publishedActivities = activityCaptor.getAllValues();
 
     long projectDeletedEvents = publishedActivities.stream()
-        .filter(activity -> activity.getClass().getSimpleName().equals("ProjectDeletedEvent"))
+        .filter(activity -> activity instanceof ProjectDeletedEvent)
         .count();
     assertEquals(1, projectDeletedEvents);
 
     long userDeletedEvents = publishedActivities.stream()
-        .filter(activity -> activity.getClass().getSimpleName().equals("UserDeletedEvent"))
+        .filter(activity -> activity instanceof UserDeletedEvent)
         .count();
     assertEquals(1, userDeletedEvents);
 
     long unassignUserEvents = publishedActivities.stream()
-        .filter(activity -> activity.getClass().getSimpleName().equals("UnassignUserEvent"))
+        .filter(activity -> activity instanceof UnassignUserEvent)
         .count();
     assertEquals(2, unassignUserEvents);
 
@@ -245,17 +248,17 @@ class DeleteExpiredUsersJobTest {
     List<ActivityEvent> publishedActivities = activityCaptor.getAllValues();
 
     long projectDeletedEvents = publishedActivities.stream()
-        .filter(activity -> activity.getClass().getSimpleName().equals("ProjectDeletedEvent"))
+        .filter(activity -> activity instanceof ProjectDeletedEvent)
         .count();
-    assertEquals(1, projectDeletedEvents, "Should have 1 ProjectDeletedEvent (even with 0 projects)");
+    assertEquals(1, projectDeletedEvents);
 
     long userDeletedEvents = publishedActivities.stream()
-        .filter(activity -> activity.getClass().getSimpleName().equals("UserDeletedEvent"))
+        .filter(activity -> activity instanceof UserDeletedEvent)
         .count();
-    assertEquals(1, userDeletedEvents, "Should have 1 UserDeletedEvent");
+    assertEquals(1, userDeletedEvents);
 
     long unassignUserEvents = publishedActivities.stream()
-        .filter(activity -> activity.getClass().getSimpleName().equals("UnassignUserEvent"))
+        .filter(activity -> activity instanceof UnassignUserEvent)
         .count();
     assertEquals(1, unassignUserEvents);
 
@@ -272,7 +275,7 @@ class DeleteExpiredUsersJobTest {
     DeleteExpiredUsersJob.User user2 = createUser(2L, "user2@test.com");
     DeleteExpiredUsersJob.User user3 = createUser(3L, "user3@test.com");
     List<DeleteExpiredUsersJob.User> expiredUsers = List.of(user1, user2, user3);
-    List<Long> personalProjectIds = List.of(10L, 20L, 30L, 40L); // 4 personal projects
+    List<Long> personalProjectIds = List.of(10L, 20L, 30L, 40L);
     List<DeleteExpiredUsersJob.ProjectOrganization> nonPersonalProjects = List.of(
         createProjectOrganization(100L, 1L),
         createProjectOrganization(200L, 2L)
@@ -297,19 +300,19 @@ class DeleteExpiredUsersJobTest {
     List<ActivityEvent> publishedActivities = activityCaptor.getAllValues();
 
     long projectDeletedEvents = publishedActivities.stream()
-        .filter(activity -> activity.getClass().getSimpleName().equals("ProjectDeletedEvent"))
+        .filter(activity -> activity instanceof ProjectDeletedEvent)
         .count();
-    assertEquals(1, projectDeletedEvents, "Should have 1 ProjectDeletedEvent");
+    assertEquals(1, projectDeletedEvents);
 
     long userDeletedEvents = publishedActivities.stream()
-        .filter(activity -> activity.getClass().getSimpleName().equals("UserDeletedEvent"))
+        .filter(activity -> activity instanceof UserDeletedEvent)
         .count();
-    assertEquals(1, userDeletedEvents, "Should have 1 UserDeletedEvent");
+    assertEquals(1, userDeletedEvents);
 
     long unassignUserEvents = publishedActivities.stream()
-        .filter(activity -> activity.getClass().getSimpleName().equals("UnassignUserEvent"))
+        .filter(activity -> activity instanceof UnassignUserEvent)
         .count();
-    assertEquals(2, unassignUserEvents, "Should have 2 UnassignUserEvents");
+    assertEquals(2, unassignUserEvents);
 
     verify(messageBus, times(1)).publishEmailNotificationEvents(emailCaptor.capture());
     List<List<EmailNotificationRequest>> emailNotifications = emailCaptor.getAllValues();

--- a/src/test/java/com/epam/reportportal/jobs/clean/DeleteExpiredUsersJobTest.java
+++ b/src/test/java/com/epam/reportportal/jobs/clean/DeleteExpiredUsersJobTest.java
@@ -237,7 +237,6 @@ class DeleteExpiredUsersJobTest {
     // Then
     assertNotNull(deleteExpiredUsersJob);
     assertEquals(1, expiredUsers.size());
-    assertTrue(personalProjectIds.isEmpty());
     assertEquals(1, nonPersonalProjects.size());
 
     verify(dataStorageService, times(1)).deleteAll(anyList());


### PR DESCRIPTION
This PR modifies the 'DeleteExpiredUsersJob' to remove inactive users along with their personal organizations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expired-user cleanup now deletes associated personal organizations/projects, unassigns users from shared projects, and records organization context on activity entries with timestamp precision improvements.

* **Documentation**
  * Updated description of the expired-user cleanup behavior.

* **Tests**
  * Added comprehensive unit tests covering multiple expired-user scenarios and event publishing.

* **Chores**
  * Test tooling switched to Mockito with JUnit 5; removed obsolete test dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->